### PR TITLE
#34 - feat: API 문서화

### DIFF
--- a/server/src/main/java/mainproject/domain/challenge/controller/ChallengeController.java
+++ b/server/src/main/java/mainproject/domain/challenge/controller/ChallengeController.java
@@ -1,5 +1,8 @@
 package mainproject.domain.challenge.controller;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import mainproject.domain.challenge.dto.ChallengePostDto;
 import mainproject.domain.challenge.dto.ChallengeResponseDto;
 import mainproject.domain.challenge.entity.Challenge;
@@ -20,6 +23,7 @@ import java.util.List;
 @RestController
 @RequestMapping(value = "/api/challenges")
 @Validated
+@Api(tags = "챌린지 생성, 조회, 삭제")
 public class ChallengeController {
     private final ChallengeService challengeService;
     private final ChallengeMapper mapper;
@@ -30,8 +34,10 @@ public class ChallengeController {
     }
 
     // 챌린지 생성
+    @ApiOperation(value = "챌린지 생성")
     @PostMapping
-    public ResponseEntity postChallenge(@RequestBody ChallengePostDto request) {
+    public ResponseEntity postChallenge(@ApiParam(name = "챌린지 상세정보 입력", value = postChallengeDescription, required = true)
+                                            @RequestBody ChallengePostDto request) {
         Challenge challenge = challengeService.createChallenge(mapper.challengePostDtoToChallenge(request));
 
         ChallengeResponseDto response = mapper.challengeToChallengeResponseDto(challenge);
@@ -39,9 +45,21 @@ public class ChallengeController {
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
+    final String postChallengeDescription = "hostMemberId: 회원번호 (회원 등록 후 챌린지 생성 가능)" + "\r\n" +
+            "category: 카테고리 (우리동네, 운동, 생활, 기타 중 입력)" + "\r\n" +
+            "title: 챌린지 제목 (50자까지 입력 가능) " + "\r\n" +
+            "content: 챌린지 설명 (500자까지 입력 가능) " + "\r\n" +
+            "startAt: 챌린지 시작 날짜 예) 2023-02-01 (내일 이후부터 선택 가능)" + "\r\n" +
+            "endAt: 챌린지 종료 날짜 (시작 날짜 이후로 설정 가능)" + "\r\n" +
+            "frequency: 인증 빈도 (생략 가능, default = 매일)" + "\r\n" +
+            "snapshotStartAt: 인증 시작 시간 예) 00:00 (생략 가능, default = 00:00:00)" + "\r\n" +
+            "snapshotEndAt: 인증 종료 시간 (시작 시간 이후로 설정 가능, 생략 가능, default = 23:59:59)";
+
     // 챌린지 목록 최신순 조회
+    @ApiOperation(value = "챌린지 목록 최신순 조회")
     @GetMapping("/new")
-    public ResponseEntity getNewChallenges(@RequestParam @Nullable Category category) {
+    public ResponseEntity getNewChallenges(@ApiParam(name = "카테고리 선택", value = "미선택시 전체 카테고리에서 조회", required = false)
+                                               @RequestParam @Nullable Category category) {
         List<Challenge> challenges = challengeService.findNewChallenges(category);
 
         List<ChallengeResponseDto> response = mapper.challengesToChallengeResponseDtos(challenges);
@@ -51,8 +69,10 @@ public class ChallengeController {
     }
 
     // 챌린지 목록 참여자순 조회
+    @ApiOperation(value = "챌린지 목록 참여자순 조회")
     @GetMapping("/hot")
-    public ResponseEntity getHotChallenges(@RequestParam @Nullable Category category) {
+    public ResponseEntity getHotChallenges(@ApiParam(name = "카테고리 선택", value = "미선택시 전체 카테고리에서 조회", required = false)
+                                               @RequestParam @Nullable Category category) {
         List<Challenge> challenges = challengeService.findHotChallenges(category);
 
         List<ChallengeResponseDto> response = mapper.challengesToChallengeResponseDtos(challenges);
@@ -61,8 +81,10 @@ public class ChallengeController {
     }
 
     // 회원이 생성한 챌린지 조회
+    @ApiOperation(value = "회원이 생성한 챌린지 조회")
     @GetMapping("/{member-id}")
-    public ResponseEntity getCreateChallenges(@PathVariable("member-id") @Positive long memberId) {
+    public ResponseEntity getCreateChallenges(@ApiParam(name = "회원번호 입력", required = true)
+                                                  @PathVariable("member-id") @Positive long memberId) {
         List<Challenge> challenges = challengeService.findCreateChallenges(memberId);
 
         List<ChallengeResponseDto> response = mapper.challengesToChallengeResponseDtos(challenges);
@@ -71,8 +93,10 @@ public class ChallengeController {
     }
 
     // 챌린지 검색(제목+내용)
+    @ApiOperation(value = "챌린지 검색(제목+내용)")
     @GetMapping
-    public ResponseEntity getSearchChallenges(@RequestParam @NotNull(message = "검색어를 입력하세요.")
+    public ResponseEntity getSearchChallenges(@ApiParam(name = "검색어", value = "100자까지 입력 가능", required = true)
+                                                  @RequestParam @NotNull(message = "검색어를 입력하세요.")
                                                   @Size(max = 100, message = "검색어는 100자까지 입력 가능합니다.")
                                                   String query) {
         List<Challenge> challenges = challengeService.searchChallenges(query);
@@ -83,8 +107,10 @@ public class ChallengeController {
     }
 
     // 챌린지 삭제
+    @ApiOperation(value = "챌린지 삭제")
     @DeleteMapping("/{challenge-id}")
-    public ResponseEntity deleteChallenge(@PathVariable("challenge-id") @Positive long challengeId) {
+    public ResponseEntity deleteChallenge(@ApiParam(name = "챌린지번호 입력", required = true)
+                                              @PathVariable("challenge-id") @Positive long challengeId) {
         challengeService.deleteChallenge(challengeId);
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);

--- a/server/src/main/java/mainproject/domain/challenge/controller/ChallengeController.java
+++ b/server/src/main/java/mainproject/domain/challenge/controller/ChallengeController.java
@@ -52,7 +52,7 @@ public class ChallengeController {
             "startAt: 챌린지 시작 날짜 예) 2023-02-01 (내일 이후부터 선택 가능)" + "\r\n" +
             "endAt: 챌린지 종료 날짜 (시작 날짜 이후로 설정 가능)" + "\r\n" +
             "frequency: 인증 빈도 (생략 가능, default = 매일)" + "\r\n" +
-            "snapshotStartAt: 인증 시작 시간 예) 00:00 (생략 가능, default = 00:00:00)" + "\r\n" +
+            "snapshotStartAt: 인증 시작 시간 예) 00:00:00 (생략 가능, default = 00:00:00)" + "\r\n" +
             "snapshotEndAt: 인증 종료 시간 (시작 시간 이후로 설정 가능, 생략 가능, default = 23:59:59)";
 
     // 챌린지 목록 최신순 조회

--- a/server/src/main/java/mainproject/domain/challenge/dto/ChallengePostDto.java
+++ b/server/src/main/java/mainproject/domain/challenge/dto/ChallengePostDto.java
@@ -63,11 +63,11 @@ public class ChallengePostDto {
     @ApiModelProperty(required = false, example = "매일")
     private Frequency frequency = Frequency.매일; // 기본값 - 매일
 
-    @ApiModelProperty(required = false, example = "00:00")
+    @ApiModelProperty(required = false, example = "00:00:00")
     @JsonFormat(pattern = "HH:mm:ss", shape = JsonFormat.Shape.STRING)
     private LocalTime snapshotStartAt = LocalTime.parse("00:00:00", DateTimeFormatter.ofPattern("HH:mm:ss"));  // 기본값 - 00:00:00
 
-    @ApiModelProperty(required = false, example = "23:59")
+    @ApiModelProperty(required = false, example = "23:59:00")
     @JsonFormat(pattern = "HH:mm:ss", shape = JsonFormat.Shape.STRING)
     private LocalTime snapshotEndAt = LocalTime.parse("23:59:59", DateTimeFormatter.ofPattern("HH:mm:ss"));    // 기본값 - 23:59:59
 

--- a/server/src/main/java/mainproject/domain/challenge/dto/ChallengePostDto.java
+++ b/server/src/main/java/mainproject/domain/challenge/dto/ChallengePostDto.java
@@ -1,5 +1,7 @@
 package mainproject.domain.challenge.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import mainproject.domain.challenge.entity.Frequency;
 import mainproject.domain.member.entity.Member;
@@ -14,8 +16,10 @@ import java.time.format.DateTimeFormatter;
 public class ChallengePostDto {
     @NotNull
     @Positive
+    @ApiModelProperty(required = true, example = "1")
     private long hostMemberId;
 
+    @ApiModelProperty(hidden = true)
     public Member getMember() {
         Member member = new Member();
         member.setId(hostMemberId);
@@ -23,38 +27,52 @@ public class ChallengePostDto {
     }
 
     @NotNull(message = "카테고리를 선택하세요.")
+    @ApiModelProperty(required = true, example = "우리동네")
     private Category category;
 
     @NotBlank(message = "제목을 입력하세요.")
     @Size(max = 50, message = "제목은 50자까지 입력 가능합니다.")
+    @ApiModelProperty(required = true, example = "같이 운동해요~")
     private String title;
 
     @NotBlank(message = "설명을 입력하세요.")
     @Size(max = 500, message = "설명은 500자까지 입력 가능합니다.")
+    @ApiModelProperty(required = true, example = "우리동네에서 운동 후 하루에 한 번 인증사진을 등록하시면 됩니다.")
     private String content;
 
     // private Image challengeImage;  // TODO: 이미지파일
 
     @NotNull(message = "시작 날짜를 선택하세요.")
     //@Future(message = "시작 날짜는 내일 이후부터 선택 가능합니다.") // 챌린지 상태변화 테스트시 주석 처리
+    @ApiModelProperty(required = true, example = "2023-02-01")
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
     private LocalDate startAt;
 
     @NotNull(message = "종료 날짜를 선택하세요.")
+    @ApiModelProperty(required = true, example = "2023-12-31")
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
     private LocalDate endAt;
 
     @AssertTrue(message = "종료 날짜는 시작 날짜 이후부터 선택 가능합니다.")
+    @ApiModelProperty(hidden = true)
     public boolean isValidChallengePeriod() {
         return endAt.isAfter(startAt);
     }
 
     @NotNull(message = "인증 빈도를 선택하세요.")
+    @ApiModelProperty(required = false, example = "매일")
     private Frequency frequency = Frequency.매일; // 기본값 - 매일
-    
+
+    @ApiModelProperty(required = false, example = "00:00")
+    @JsonFormat(pattern = "HH:mm:ss", shape = JsonFormat.Shape.STRING)
     private LocalTime snapshotStartAt = LocalTime.parse("00:00:00", DateTimeFormatter.ofPattern("HH:mm:ss"));  // 기본값 - 00:00:00
 
+    @ApiModelProperty(required = false, example = "23:59")
+    @JsonFormat(pattern = "HH:mm:ss", shape = JsonFormat.Shape.STRING)
     private LocalTime snapshotEndAt = LocalTime.parse("23:59:59", DateTimeFormatter.ofPattern("HH:mm:ss"));    // 기본값 - 23:59:59
 
     @AssertTrue(message = "종료 시간은 시작 시간 이후부터 선택 가능합니다.")
+    @ApiModelProperty(hidden = true)
     public boolean isValidSnapshotTime() {
         return snapshotEndAt.isAfter(snapshotStartAt);
     }

--- a/server/src/main/java/mainproject/domain/challenge/dto/ChallengeResponseDto.java
+++ b/server/src/main/java/mainproject/domain/challenge/dto/ChallengeResponseDto.java
@@ -26,5 +26,5 @@ public class ChallengeResponseDto {
     private LocalTime snapshotEndAt;
     private LocalDateTime createdAt;
     private ChallengeStatus challengeStatus;
-    // TODO: 참가자 수
+    private long challengerCount;
 }

--- a/server/src/main/java/mainproject/domain/challenge/entity/Challenge.java
+++ b/server/src/main/java/mainproject/domain/challenge/entity/Challenge.java
@@ -76,7 +76,8 @@ public class Challenge implements Serializable {
     @Column(nullable = false)
     private ChallengeStatus challengeStatus;
 
-    // TODO: 참가자 수
+    @Column(nullable = false)
+    private long challengerCount = 0;
 
     @OneToMany(mappedBy = "challenge")
     private List<Challenger> challengers = new ArrayList<>();

--- a/server/src/main/java/mainproject/domain/challenger/Service/ChallengerService.java
+++ b/server/src/main/java/mainproject/domain/challenger/Service/ChallengerService.java
@@ -49,6 +49,7 @@ public class ChallengerService {
 
         challenger.setMember(member);
         challenger.setChallenge(challenge);
+        challenger.getChallenge().setChallengerCount(challenge.getChallengerCount() + 1);   // 참가자 수 증가
         challenger.setChallengerId(challengerId);
         return challengerRepository.save(challenger);
     }

--- a/server/src/main/java/mainproject/global/config/SwaggerConfiguration.java
+++ b/server/src/main/java/mainproject/global/config/SwaggerConfiguration.java
@@ -18,7 +18,7 @@ public class SwaggerConfiguration {
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
-                .useDefaultResponseMessages(false)
+                .useDefaultResponseMessages(false)  // 기본 상태 코드에 대한 디폴트 메세지 비활성화
                 .select() // ApiSelectorBuilder를 생성하여 apis()와 paths()를 사용할 수 있게 해준다.
                 .apis(RequestHandlerSelectors.any())  // api 스펙이 작성되어 있는 패키지(Controller가 존재하는 패키지)를 지정하여 API를 문서화한다.
                 .paths(PathSelectors.any())   // apis()로 선택되어진 API중 특정 path 조건에 맞는 API들을 다시 필터링하여 문서화한다.

--- a/server/src/main/java/mainproject/global/exception/ExceptionCode.java
+++ b/server/src/main/java/mainproject/global/exception/ExceptionCode.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum ExceptionCode {
     CHALLENGE_NOT_FOUND(404, "챌린지를 찾을 수 없습니다."),
-    CHALLENGE_DELETE_NOT_ALLOWED(405, "챌린지를 삭제할 수 없습니다."),
+    CHALLENGER_ALREADY_EXISTS(405, "챌린지 참가자가 존재하므로 삭제할 수 없습니다."),
     CHALLENGE_ALREADY_STARTED(405, "이미 시작 혹은 종료된 챌린지입니다."),
     CHALLENGE_NOT_IN_PROGRESS(405, "진행 중인 챌린지가 아닙니다."),
     MEMBER_ALREADY_START_CHALLENGE(403, "이미 참가 중인 챌린지입니다."),

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,3 +1,0 @@
-spring.redis.host=localhost
-
-spring.redis.port=6379

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -7,6 +7,9 @@ spring:
     url: jdbc:h2:mem:test
   jpa:
     show-sql: true
+  redis:
+    host: localhost
+    port: '6379'
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher


### PR DESCRIPTION
## 작업내용
- 챌린지 참가자 수 조회기능 구현 후 인기순 조회 메서드 수정
- Swagger를 사용한 API 문서화: Challenge 생성, 조회, 삭제 기능
- yaml파일 통합

Related: #34

## PR Checklist
- [x] PR Title을 다음 예시와 같이 작성했습니다. (e.g. #12 - feat: 회원가입 기능 구현)
- [x] 우측의 Reviewers, Assignees, Labels, Projects, Milestone을 적절하게 선택했습니다.
