### PR TITLE
#11 - style: 전체 페이지 크기 조절, 마이페이지 컴포넌트 크기 조절

### DIFF
--- a/client/src/components/Button.js
+++ b/client/src/components/Button.js
@@ -86,7 +86,7 @@ const StyledBasicBtn = styled.button`
 	background-color: ${(props) => props.background || "white"};
 	cursor: pointer;
 	margin: ${(props) => props.margin || "0.3rem"};
-	box-shadow: 0 0.3rem 0.4rem rgba(0, 0, 0, 0.6);
+	/* box-shadow: 0 0.3rem 0.4rem rgba(0, 0, 0, 0.6); */
 
 	text-align: center;
 	font-family: "Inter";

--- a/client/src/components/Category.js
+++ b/client/src/components/Category.js
@@ -68,20 +68,24 @@ export const SelectCategory = () => {
 };
 
 const MainCategoryContainer = styled.div`
-	/* border: 1px solid black; */
-	width: 36.4rem;
+	border: 1px solid black;
+	width: 100%;
+	max-width: 480px;
 	height: 9.8rem;
 	padding: 1rem 0;
 	display: flex;
 	align-items: center;
 	position: fixed;
 	top: 5.2rem;
-	z-index: 9999;
+	right: 0;
+	left: 0;
+	margin: 0 auto;
+	/* z-index: 9999; */
 	background-color: white;
 `;
 
 const CategoryItemContainer = styled.div`
-	width: 9.1rem;
+	width: 25%;
 	height: 7.8rem;
 	display: flex;
 	flex-direction: column;

--- a/client/src/components/Challenge.js
+++ b/client/src/components/Challenge.js
@@ -73,7 +73,7 @@ const ChallengeStateContainer = styled.div`
 		display: flex;
 		align-items: center;
 		gap: 1rem;
-		font-size: 2rem;
+		font-size: 2.5rem;
 		padding: 0 1rem;
 
 		img {
@@ -83,7 +83,7 @@ const ChallengeStateContainer = styled.div`
 	}
 
 	.container {
-		width: 36.4rem;
+		width: 100%;
 		height: 8.1rem;
 		display: flex;
 		padding: 0 1rem;
@@ -94,7 +94,7 @@ const ChallengeStateContainer = styled.div`
 			flex-direction: column;
 			justify-content: center;
 			align-items: center;
-			font-size: 2rem;
+			font-size: 2.5rem;
 		}
 
 		div:not(:last-of-type) {
@@ -128,9 +128,9 @@ const ChallengeImg = styled.div`
 	width: 16rem;
 	height: 14.5rem;
 
-	.deleteBtn {
+	/* .deleteBtn {
 		display: none;
-	}
+	} */
 `;
 
 const CreateChallengeContainer = styled.div`
@@ -143,9 +143,4 @@ const CreateChallengeContainer = styled.div`
 	justify-content: space-evenly;
 	font-size: 1.4rem;
 	margin-top: 2.5rem;
-
-	/* .deleteBtn {
-		position: fixed;
-		left: 0;
-	} */
 `;

--- a/client/src/components/Challenge.js
+++ b/client/src/components/Challenge.js
@@ -63,7 +63,7 @@ export const ChallengeState = (props) => {
 
 const ChallengeStateContainer = styled.div`
 	border: 1px solid black;
-	width: 36.4rem;
+	width: 100%;
 	height: 15rem;
 	display: flex;
 	flex-direction: column;

--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -3,7 +3,7 @@ import { FaUsers, FaRegUserCircle } from "react-icons/fa";
 import { BsGraphUp } from "react-icons/bs";
 import { AiOutlineHome } from "react-icons/ai";
 import theme from "./theme";
-import { Link, NavLink } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 
 export const Footer = () => {
 	return (
@@ -29,19 +29,22 @@ export const Footer = () => {
 };
 
 const FooterContainer = styled.div`
-	/* border: 1px solid black; */
+	border: 1px solid black;
 	width: 100%;
 	height: 6.5rem;
 	display: flex;
+	background-color: white;
 	position: fixed;
 	bottom: 0;
-	/* z-index: 9999; */
-	background-color: white;
+	right: 0;
+	left: 0;
+	z-index: 9999;
+	padding: 0 1.3rem;
 `;
 
 const BottomItem = styled(NavLink)`
 	border: none;
-	width: 9.1rem;
+	width: 25%;
 	height: 6.5rem;
 	padding: 0;
 	display: flex;

--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -31,6 +31,7 @@ export const Footer = () => {
 const FooterContainer = styled.div`
 	border: 1px solid black;
 	width: 100%;
+	max-width: 480px;
 	height: 6.5rem;
 	display: flex;
 	background-color: white;
@@ -38,7 +39,7 @@ const FooterContainer = styled.div`
 	bottom: 0;
 	right: 0;
 	left: 0;
-	z-index: 9999;
+	margin: 0 auto;
 	padding: 0 1.3rem;
 `;
 
@@ -46,7 +47,6 @@ const BottomItem = styled(NavLink)`
 	border: none;
 	width: 25%;
 	height: 6.5rem;
-	padding: 0;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -3,7 +3,7 @@ import { FaUsers, FaRegUserCircle } from "react-icons/fa";
 import { BsGraphUp } from "react-icons/bs";
 import { AiOutlineHome } from "react-icons/ai";
 import theme from "./theme";
-import { Link } from "react-router-dom";
+import { Link, NavLink } from "react-router-dom";
 
 export const Footer = () => {
 	return (
@@ -35,11 +35,11 @@ const FooterContainer = styled.div`
 	display: flex;
 	position: fixed;
 	bottom: 0;
-	z-index: 9999;
+	/* z-index: 9999; */
 	background-color: white;
 `;
 
-const BottomItem = styled(Link)`
+const BottomItem = styled(NavLink)`
 	border: none;
 	width: 9.1rem;
 	height: 6.5rem;
@@ -53,4 +53,8 @@ const BottomItem = styled(Link)`
 	text-decoration: none;
 	color: black;
 	font-size: 2rem;
+
+	&.active {
+		color: ${theme.color.green};
+	}
 `;

--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -30,7 +30,7 @@ export const Footer = () => {
 
 const FooterContainer = styled.div`
 	/* border: 1px solid black; */
-	width: 36.4rem;
+	width: 100%;
 	height: 6.5rem;
 	display: flex;
 	position: fixed;

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -52,27 +52,32 @@ export const MypageHeader = (props) => {
 };
 
 const Main = styled.div`
-	/* border: 1px solid black; */
-	width: 36.4rem;
+	border: 1px solid black;
+	width: 100%;
 	height: 5.2rem;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	position: fixed;
-	top: 0;
-	/* z-index: 9999; */
 	background-color: white;
+	position: fixed;
+	left: 0;
+	right: 0;
+	top: 0;
+	z-index: 9999;
+	padding: 0 1.3rem;
 `;
 
 const Title = styled.div`
 	border: 1px solid black;
-	width: 36.4rem;
+	width: 100%;
 	height: 5.2rem;
 	font-size: 1.6rem;
 	font-weight: bold;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	position: fixed;
+	top: 0;
 
 	.icon {
 		font-size: 2rem;

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -60,7 +60,7 @@ const Main = styled.div`
 	justify-content: space-between;
 	position: fixed;
 	top: 0;
-	z-index: 9999;
+	/* z-index: 9999; */
 	background-color: white;
 `;
 

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -53,23 +53,26 @@ export const MypageHeader = (props) => {
 
 const Main = styled.div`
 	border: 1px solid black;
+	background-color: white;
 	width: 100%;
+	max-width: 480px;
 	height: 5.2rem;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	background-color: white;
 	position: fixed;
+	top: 0;
 	left: 0;
 	right: 0;
-	top: 0;
-	z-index: 9999;
+	margin: 0 auto;
 	padding: 0 1.3rem;
 `;
 
 const Title = styled.div`
 	border: 1px solid black;
+	background-color: white;
 	width: 100%;
+	max-width: 480px;
 	height: 5.2rem;
 	font-size: 1.6rem;
 	font-weight: bold;
@@ -78,6 +81,10 @@ const Title = styled.div`
 	justify-content: space-between;
 	position: fixed;
 	top: 0;
+	left: 0;
+	right: 0;
+	margin: 0 auto;
+	padding: 0 1.3rem;
 
 	.icon {
 		font-size: 2rem;

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -65,6 +65,7 @@ const Main = styled.div`
 	left: 0;
 	right: 0;
 	margin: 0 auto;
+	/* z-index: 999; */
 	padding: 0 1.3rem;
 `;
 

--- a/client/src/components/MypageSetting.js
+++ b/client/src/components/MypageSetting.js
@@ -1,6 +1,7 @@
 import styled, { css } from "styled-components";
 import { Btn } from "./Button";
 import { NavTitle } from "./NavItem";
+import theme from "./theme";
 
 export const MypageSetting = (props) => {
 	const { menuOpen, setMenuOpen, modalToLogout, modalToQuit } = props;
@@ -17,14 +18,14 @@ export const MypageSetting = (props) => {
 				size="2rem"
 				width="6rem"
 				height="2.2rem"
-				background="black"
+				background={theme.color.green}
 				onClick={toggleMenu}
 			/>
 			<div>
-				<NavTitle title="프로필 수정" link="/editProfile" width="20rem" />
-				<NavTitle title="비밀번호 변경" link="/changePw" width="20rem" />
-				<NavTitle title="로그아웃" width="20rem" onClick={modalToLogout} />
-				<NavTitle title="회원탈퇴" width="20rem" onClick={modalToQuit} />
+				<NavTitle title="프로필 수정" link="/editProfile" width="100%" />
+				<NavTitle title="비밀번호 변경" link="/changePw" width="100%" />
+				<NavTitle title="로그아웃" width="100%" onClick={modalToLogout} />
+				<NavTitle title="회원탈퇴" width="100%" onClick={modalToQuit} />
 			</div>
 		</SettingWrapper>
 	);
@@ -34,16 +35,15 @@ const SettingWrapper = styled.div`
 	border: 1px solid black;
 	padding: 2rem 1.3rem;
 	gap: 1rem;
-	height: 79.1rem;
-	width: 21rem;
+	width: 100%;
 	background-color: white;
-	transform: translateX(39rem);
 	display: none;
-	position: absolute;
+	position: fixed;
+	top: 5.2rem;
+	/* display: block; */
 	${(props) =>
 		props.menuOpen &&
 		css`
 			display: block;
-			transform: translateX(7.7rem);
 		`}
 `;

--- a/client/src/components/MypageSetting.js
+++ b/client/src/components/MypageSetting.js
@@ -36,6 +36,7 @@ const SettingWrapper = styled.div`
 	padding: 2rem 1.3rem;
 	gap: 1rem;
 	width: 100%;
+	max-width: 480px;
 	background-color: white;
 	display: none;
 	position: fixed;

--- a/client/src/components/NavItem.js
+++ b/client/src/components/NavItem.js
@@ -29,9 +29,9 @@ export const ArrowLeft = () => {
 
 const Navbar = styled.div`
 	/* border: 1px solid black; */
-	width: ${(props) => props.width || "36rem"};
+	/* width: ${(props) => props.width || "36rem"}; */
 	height: 4.7rem;
-	font-size: 1.4rem;
+	font-size: 1.6rem;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -8,11 +8,16 @@
 body {
 	border: 1px solid orange;
 	padding: 0 1.3rem;
-	max-width: 789px;
-	min-height: 844px;
-	/* overflow: scroll; */
+	max-width: 480px;
+	height: 100%;
+	/* min-height: 844px;
+	max-height: 844px; */
+	overflow: scroll;
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	margin: 0 auto;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -6,5 +6,10 @@
 }
 
 body {
+	border: 1px solid black;
 	padding: 0 1.3rem;
+	max-width: 789px;
+	/* display: flex;
+	justify-content: center;
+	align-items: center; */
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -6,18 +6,11 @@
 }
 
 body {
-	border: 1px solid orange;
+	border: 1px solid black;
 	padding: 0 1.3rem;
 	max-width: 480px;
-	height: 100%;
-	/* min-height: 844px;
-	max-height: 844px; */
+	min-width: 390px;
+	min-height: 100vh;
 	overflow: scroll;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
+	margin: 0 auto;
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -6,10 +6,13 @@
 }
 
 body {
-	border: 1px solid black;
+	border: 1px solid orange;
 	padding: 0 1.3rem;
 	max-width: 789px;
-	/* display: flex;
+	min-height: 844px;
+	/* overflow: scroll; */
+	display: flex;
 	justify-content: center;
-	align-items: center; */
+	align-items: center;
+	margin: 0 auto;
 }

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -11,9 +11,7 @@ root.render(
 	<React.StrictMode>
 		<Provider store={store}>
 			<BrowserRouter>
-				<div className="AppContainer">
 					<App />
-				</div>
 			</BrowserRouter>
 		</Provider>
 	</React.StrictMode>,

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -11,7 +11,9 @@ root.render(
 	<React.StrictMode>
 		<Provider store={store}>
 			<BrowserRouter>
-				<App />
+				<div className="AppContainer">
+					<App />
+				</div>
 			</BrowserRouter>
 		</Provider>
 	</React.StrictMode>,

--- a/client/src/pages/FindPassword.js
+++ b/client/src/pages/FindPassword.js
@@ -58,10 +58,11 @@ export const FindPassword = () => {
 const Wrapper = styled.div`
 	/* border: 1px solid black; */
 	width: 100%;
-	/* height: 79.2rem; */
+	min-height: 100vh;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	justify-content: center;
 	gap: 2rem;
 
 	div {

--- a/client/src/pages/FindPassword.js
+++ b/client/src/pages/FindPassword.js
@@ -56,9 +56,9 @@ export const FindPassword = () => {
 };
 
 const Wrapper = styled.div`
-	border: 1px solid black;
-	width: 36.4rem;
-	height: 79.2rem;
+	/* border: 1px solid black; */
+	width: 100%;
+	/* height: 79.2rem; */
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -44,7 +44,6 @@ const Home = () => {
 };
 
 const HomeWrapper = styled.div`
-	border: 1px solid red;
 	margin-top: 15rem;
 	margin-bottom: 6.5rem;
 `;
@@ -54,7 +53,6 @@ const StyledH1 = styled.h1`
 `;
 
 const HomeChallengeItemContainer = styled.div`
-	border: 1px solid pink;
 	display: flex;
 	flex-wrap: wrap;
 `;

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -5,56 +5,58 @@ import { HomeChallengeItem } from "../components/ChallengeItem";
 import { BackToTopBtn } from "../components/Button";
 
 const Home = () => {
-  const categoryId = 1;
-  const challengeId = 1;
-  
-  return (
-    <HomeWrapper>
-      <HomeCategory NavTo="challenges" />
-      <StyledH1>BEST</StyledH1>
-      {/* map */}
-      <HomeChallengeItemContainer>
-        {/* <HomeChallengeItem
+	const categoryId = 1;
+	const challengeId = 1;
+
+	return (
+		<HomeWrapper>
+			<HomeCategory NavTo="challenges" />
+			<StyledH1>BEST</StyledH1>
+			{/* map */}
+			<HomeChallengeItemContainer>
+				{/* <HomeChallengeItem
           imgUrl={challenge.imgUrl}
           challengeTitle={challenge.title}
           challengerNum={challenge.challengerNum}
           challengeFrequency={challenge.frequency}
           challengeDate={challenge.date}
         /> */}
-        <HomeChallengeItem
-          imgUrl=""
-          challengeTitle="아침 8시 기상 후 조깅하기"
-          challengerNum="299명"
-          challengeFrequency="주 3일"
-          challengeDate="1.18 - 1.25"
-          NavTo={`/challenges/${categoryId}/${challengeId}`}
-        />
-        <HomeChallengeItem
-          imgUrl=""
-          challengeTitle="아침 8시 기상 후 조깅하기"
-          challengerNum="299명"
-          challengeFrequency="주 3일"
-          challengeDate="1.18 - 1.25"
-          NavTo={`/challenges/${categoryId}/${challengeId}`}
-        />
-      </HomeChallengeItemContainer>
-      <BackToTopBtn />
-    </HomeWrapper>
-  );
+				<HomeChallengeItem
+					imgUrl=""
+					challengeTitle="아침 8시 기상 후 조깅하기"
+					challengerNum="299명"
+					challengeFrequency="주 3일"
+					challengeDate="1.18 - 1.25"
+					NavTo={`/challenges/${categoryId}/${challengeId}`}
+				/>
+				<HomeChallengeItem
+					imgUrl=""
+					challengeTitle="아침 8시 기상 후 조깅하기"
+					challengerNum="299명"
+					challengeFrequency="주 3일"
+					challengeDate="1.18 - 1.25"
+					NavTo={`/challenges/${categoryId}/${challengeId}`}
+				/>
+			</HomeChallengeItemContainer>
+			<BackToTopBtn />
+		</HomeWrapper>
+	);
 };
 
 const HomeWrapper = styled.div`
-  margin-top: 15rem;
-  margin-bottom: 6.5rem;
+	border: 1px solid red;
+	margin-top: 15rem;
+	margin-bottom: 6.5rem;
 `;
 
 const StyledH1 = styled.h1`
-  font-size: 2rem;
+	font-size: 2rem;
 `;
 
 const HomeChallengeItemContainer = styled.div`
-  display: flex;
-  flex-wrap: wrap;
+	border: 1px solid pink;
+	display: flex;
+	flex-wrap: wrap;
 `;
 
 export default Home;

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -73,7 +73,7 @@ export const Login = () => {
 
 	return (
 		<Wrapper onSubmit={onSubmit}>
-			<div />
+			{/* <div /> */}
 			<div>
 				<InputAuth
 					label="이메일"
@@ -113,9 +113,9 @@ export const Login = () => {
 };
 
 const Wrapper = styled.form`
-	border: 1px solid black;
-	width: 36.4rem;
-	height: 79.2rem;
+	/* border: 1px solid black; */
+	width: 100%;
+	/* height: 79.2rem; */
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -115,10 +115,11 @@ export const Login = () => {
 const Wrapper = styled.form`
 	/* border: 1px solid black; */
 	width: 100%;
-	/* height: 79.2rem; */
+	min-height: 100vh;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	justify-content: center;
 	gap: 4rem;
 
 	input {

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -64,7 +64,7 @@ export const MyPage = (props) => {
 				{props.name || "유저이름"}
 			</div>
 			<ChallengeState />
-			<div>
+			<div className="challengeNav">
 				<NavTitle title="생성한 챌린지" link="/userCreate" />
 				<NavTitle title="완료한 챌린지" link="/userComplete" />
 			</div>
@@ -74,24 +74,28 @@ export const MyPage = (props) => {
 };
 
 const MypageWrapper = styled.div`
-	border: 1px solid black;
+	border: 1px solid orange;
 	width: 100%;
-	/* height: 100rem; */
+	min-height: 100vh;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	justify-content: space-between;
+	justify-content: center;
+	gap: 2rem;
+
+	.challengeNav {
+		width: 100%;
+	}
 
 	.userInfo {
-		border: 1px solid red;
 		width: 100%;
 		height: 50%;
 		display: flex;
 		justify-content: flex-start;
 		align-items: center;
 		gap: 3rem;
-		font-size: 1.4rem;
-		padding: 0 1rem;
+		font-size: 1.5rem;
+		padding: 1rem;
 
 		img {
 			border: 1px solid black;

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -75,8 +75,8 @@ export const MyPage = (props) => {
 
 const MypageWrapper = styled.div`
 	border: 1px solid black;
-	width: 36.4rem;
-	height: 79.2rem;
+	width: 100%;
+	/* height: 79.2rem; */
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -58,9 +58,9 @@ export const MyPage = (props) => {
 				modalToQuit={modalToQuit}
 			/>
 			<div className="userInfo">
-				<div>
-					<img src={props.imgURL || "/images/미모티콘.png"} alt="avatar" />
-				</div>
+				{/* <div> */}
+				<img src={props.imgURL || "/images/미모티콘.png"} alt="avatar" />
+				{/* </div> */}
 				{props.name || "유저이름"}
 			</div>
 			<ChallengeState />
@@ -76,15 +76,16 @@ export const MyPage = (props) => {
 const MypageWrapper = styled.div`
 	border: 1px solid black;
 	width: 100%;
-	/* height: 79.2rem; */
+	/* height: 100rem; */
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	justify-content: space-between;
 
 	.userInfo {
-		width: 36.4rem;
-		height: 15rem;
+		border: 1px solid red;
+		width: 100%;
+		height: 50%;
 		display: flex;
 		justify-content: flex-start;
 		align-items: center;
@@ -94,8 +95,8 @@ const MypageWrapper = styled.div`
 
 		img {
 			border: 1px solid black;
-			width: 15rem;
-			height: 15rem;
+			width: 45%;
+			height: 45%;
 			border-radius: 50%;
 		}
 	}

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -57,10 +57,10 @@ export const MyPage = (props) => {
 				modalToLogout={modalToLogout}
 				modalToQuit={modalToQuit}
 			/>
+			<div />
 			<div className="userInfo">
-				{/* <div> */}
 				<img src={props.imgURL || "/images/미모티콘.png"} alt="avatar" />
-				{/* </div> */}
+
 				{props.name || "유저이름"}
 			</div>
 			<ChallengeState />
@@ -74,13 +74,13 @@ export const MyPage = (props) => {
 };
 
 const MypageWrapper = styled.div`
-	border: 1px solid orange;
+	/* border: 1px solid orange; */
 	width: 100%;
 	min-height: 100vh;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	justify-content: center;
+	justify-content: space-around;
 	gap: 2rem;
 
 	.challengeNav {
@@ -88,8 +88,8 @@ const MypageWrapper = styled.div`
 	}
 
 	.userInfo {
+		/* border: 1px solid blue; */
 		width: 100%;
-		height: 50%;
 		display: flex;
 		justify-content: flex-start;
 		align-items: center;

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -125,7 +125,7 @@ export const Signup = () => {
 			{isOpenModal && (
 				<Modal modalText="회원가입 성공! 로그인 페이지로 이동합니다." />
 			)}
-			<div />
+			{/* <div /> */}
 			<div>
 				<InputAuth
 					label="이름"
@@ -182,9 +182,9 @@ export const Signup = () => {
 };
 
 const Wrapper = styled.form`
-	border: 1px solid black;
-	width: 36.4rem;
-	min-height: 79.2rem;
+	/* border: 1px solid black; */
+	width: 100%;
+	/* min-height: 79.2rem; */
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -184,7 +184,7 @@ export const Signup = () => {
 const Wrapper = styled.form`
 	border: 1px solid black;
 	width: 36.4rem;
-	height: 79.2rem;
+	min-height: 79.2rem;
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -184,10 +184,11 @@ export const Signup = () => {
 const Wrapper = styled.form`
 	/* border: 1px solid black; */
 	width: 100%;
-	/* min-height: 79.2rem; */
+	min-height: 100vh;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	justify-content: center;
 	gap: 3rem;
 
 	input {

--- a/client/src/pages/UserCompleteChallenge.js
+++ b/client/src/pages/UserCompleteChallenge.js
@@ -22,15 +22,15 @@ export const UserCompleteChallenge = () => {
 				<CompletedChallenge title="일주일에 책 한권 이상 읽기" />
 				<CompletedChallenge title="매일 헬스장 출석 체크" />
 				<CompletedChallenge title="아이고 힘들어" />
-				<BackToTopBtn />
 			</ChallengeWrap>
+			<BackToTopBtn bottom="3rem" />
 		</>
 	);
 };
 
 const ChallengeWrap = styled.div`
-	width: 36.4rem;
-	height: 79.2rem;
+	width: 100%;
+	/* height: 79.2rem; */
 	overflow: scroll;
 	display: flex;
 	flex-wrap: wrap;

--- a/client/src/pages/UserCompleteChallenge.js
+++ b/client/src/pages/UserCompleteChallenge.js
@@ -22,7 +22,7 @@ export const UserCompleteChallenge = () => {
 				<CompletedChallenge title="일주일에 책 한권 이상 읽기" />
 				<CompletedChallenge title="매일 헬스장 출석 체크" />
 				<CompletedChallenge title="아이고 힘들어" />
-				<BackToTopBtn bottom="1rem" />
+				<BackToTopBtn />
 			</ChallengeWrap>
 		</>
 	);

--- a/client/src/pages/UserCreateChallenge.js
+++ b/client/src/pages/UserCreateChallenge.js
@@ -46,14 +46,14 @@ export const UserCreateChallenge = () => {
 				<CreatedChallenge title="아이고 힘들어" />
 				<CreatedChallenge title="아이고 힘들어" />
 			</ChallengeWrap>
-			<BackToTopBtn />
+			<BackToTopBtn bottom="3rem" />
 		</>
 	);
 };
 
 const ChallengeWrap = styled.div`
-	width: 36.4rem;
-	height: 79.2rem;
+	width: 100%;
+	/* height: 79.2rem; */
 	overflow: scroll;
 	display: flex;
 	flex-wrap: wrap;

--- a/client/src/pages/UserCreateChallenge.js
+++ b/client/src/pages/UserCreateChallenge.js
@@ -45,8 +45,8 @@ export const UserCreateChallenge = () => {
 				<CreatedChallenge title="매일 헬스장 출석 체크" />
 				<CreatedChallenge title="아이고 힘들어" />
 				<CreatedChallenge title="아이고 힘들어" />
-				<BackToTopBtn bottom="1rem" />
 			</ChallengeWrap>
+			<BackToTopBtn />
 		</>
 	);
 };

--- a/client/src/pages/UserPasswordChange.js
+++ b/client/src/pages/UserPasswordChange.js
@@ -170,9 +170,9 @@ export const UserPasswordChange = () => {
 };
 
 const Content = styled.form`
-	border: 1px solid black;
+	/* border: 1px solid black; */
 	width: 100%;
-	height: 79.2rem;
+	/* height: 79.2rem; */
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/client/src/pages/UserPasswordChange.js
+++ b/client/src/pages/UserPasswordChange.js
@@ -171,7 +171,7 @@ export const UserPasswordChange = () => {
 
 const Content = styled.form`
 	border: 1px solid black;
-	width: 36.4rem;
+	width: 100%;
 	height: 79.2rem;
 	display: flex;
 	flex-direction: column;

--- a/client/src/pages/UserProfileEdit.js
+++ b/client/src/pages/UserProfileEdit.js
@@ -81,7 +81,8 @@ export const UserProfileEdit = () => {
 };
 
 const Container = styled.form`
-	width: 36.4rem;
+	border: 1px solid black;
+	width: 100%;
 	height: 79.2rem;
 	display: flex;
 	flex-direction: column;

--- a/client/src/pages/UserProfileEdit.js
+++ b/client/src/pages/UserProfileEdit.js
@@ -81,9 +81,9 @@ export const UserProfileEdit = () => {
 };
 
 const Container = styled.form`
-	border: 1px solid black;
+	/* border: 1px solid black; */
 	width: 100%;
-	height: 79.2rem;
+	/* height: 79.2rem; */
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/client/src/router/Router.js
+++ b/client/src/router/Router.js
@@ -2,7 +2,7 @@ import { Routes, Route, Outlet } from "react-router-dom";
 // import { Suspense } from "react";
 // import { Loading } from "../components/Loading";
 import { Footer } from "../components/Footer";
-import { MainHeader } from "../components/Header";
+import { MainHeader, MypageHeader, TitleHeader } from "../components/Header";
 // challenge
 import Home from "../pages/Home";
 import HomeCategoryBoard from "../pages/HomeCategoryBoard";

--- a/client/src/router/Router.js
+++ b/client/src/router/Router.js
@@ -3,6 +3,7 @@ import { Routes, Route, Outlet } from "react-router-dom";
 // import { Loading } from "../components/Loading";
 import { Footer } from "../components/Footer";
 import { MainHeader } from "../components/Header";
+// challenge
 import Home from "../pages/Home";
 import HomeCategoryBoard from "../pages/HomeCategoryBoard";
 import ChallengeDetail from "../pages/ChallengeDetail";
@@ -10,6 +11,7 @@ import CreateChallenge from "../pages/CreateChallenge";
 import MyChallenge from "../pages/MyChallenge";
 import MyChallengeUpload from "../pages/MyChallengeUpload";
 import MyChallengeOthers from "../pages/MyChallengeOthers";
+//mypage
 import { MyPage } from "../pages/MyPage";
 import { UserCreateChallenge } from "../pages/UserCreateChallenge";
 import { UserCompleteChallenge } from "../pages/UserCompleteChallenge";
@@ -25,52 +27,25 @@ import { CreatePost } from "../pages/CreatePost";
 import { UpdatePost } from "../pages/UpdatePost";
 import { PostDetail } from "../pages/PostDetail";
 
-const Overlaps = () => {
+const Overlaps = (hasHeader, hasFooter) => {
 	return (
 		<>
-			<MainHeader />
+			{hasHeader && <MainHeader />}
 			<Outlet />
-			<Footer />
-		</>
-	);
-};
-
-const OverlapEmp = () => {
-	return (
-		<>
-			<Outlet />
-		</>
-	);
-};
-
-const OverlapFoo = () => {
-	return (
-		<>
-			<Outlet />
-			<Footer />
-		</>
-	);
-};
-
-const OverlapHead = () => {
-	return (
-		<>
-			<MainHeader />
-			<Outlet />
+			{hasFooter && <Footer />}
 		</>
 	);
 };
 
 export const OurPath = () => {
 	return (
-		// <Suspense fallback={<Loading />}>
+		// {/* // <Suspense fallback={<Loading />}> */}
 		<Routes>
-			{/* 아무것도 고정 안 된 빈 페이지  */}
-			<Route element={<OverlapEmp />}>
+			<Route element={<Overlaps hasHeader={false} hasFooter={false} />}>
 				<Route path="/userCreate" element={<UserCreateChallenge />} />
 				<Route path="/userComplete" element={<UserCompleteChallenge />} />
 				<Route path="/changePw" element={<UserPasswordChange />} />
-				<Route path="/editProfile" element={<UserProfileEdit />} />				
+				<Route path="/editProfile" element={<UserProfileEdit />} />
 				<Route path="/challenges/:categoryId" element={<HomeCategoryBoard />} />
 				<Route
 					path="/challenges/:categoryId/:challengeId"
@@ -86,16 +61,12 @@ export const OurPath = () => {
 					element={<MyChallengeOthers />}
 				/>
 			</Route>
-			{/* header + footer 고정된 페이지 */}
-			<Route element={<Overlaps />}>
-				{/* 마이페이지
-            커뮤니티 */}
+			<Route element={<Overlaps hasHeader={true} hasFooter={true} />}>
 				<Route path="/" element={<Home />} />
 				<Route path="/mychallenge" element={<MyChallenge />} />
 				<Route path="/community" element={<Community />} />
 			</Route>
-			{/* footer 고정된 페이지 */}
-			<Route element={<OverlapFoo />}>
+			<Route element={<Overlaps hasHeader={false} hasFooter={true} />}>
 				<Route path="/mypage" element={<MyPage />} />
 				<Route
 					path="/community/:categoryId"
@@ -105,8 +76,7 @@ export const OurPath = () => {
 				<Route path="/post/:postId/update" element={<UpdatePost />} />
 				<Route path="/post/:postId" element={<PostDetail />} />
 			</Route>
-			{/* header 고정된 페이지 */}
-			<Route element={<OverlapHead />}>
+			<Route element={<Overlaps hasHeader={true} hasFooter={false} />}>
 				<Route path="/signup" element={<Signup />} />
 				<Route path="/login" element={<Login />} />
 				<Route path="/findPw" element={<FindPassword />} />

--- a/client/src/router/Router.js
+++ b/client/src/router/Router.js
@@ -27,7 +27,7 @@ import { CreatePost } from "../pages/CreatePost";
 import { UpdatePost } from "../pages/UpdatePost";
 import { PostDetail } from "../pages/PostDetail";
 
-const Overlaps = (hasHeader, hasFooter) => {
+const Overlaps = ({ hasHeader, hasFooter }) => {
 	return (
 		<>
 			{hasHeader && <MainHeader />}


### PR DESCRIPTION
## 작업내용
- index.css 에서 max-width/ min-width / min-height 설정
- 헤더, 푸터, 네브바 헤더 중앙 정렬
- 푸터 메뉴 선택 시 색상 변경 
- 로그인 / 회원가입 / 비밀번호 찾기 페이지 안 컴포넌트 중앙 정렬로 위치 조정
- 마이페이지 > 프로필 수정 / 비밀번호 변경 페이지 안 컴포넌트 중앙 정렬로 위치 조정


Related: (e.g. #6,7,11)

## PR Checklist
- [ ] PR Title을 다음 예시와 같이 작성했습니다. (e.g. #12 - feat: 회원가입 기능 구현)
- [ ] 우측의 Reviewers, Assignees, Labels, Projects, Milestone을 적절하게 선택했습니다.
