### PR TITLE
#34 - feat: API 문서화

### DIFF
--- a/server/src/main/java/mainproject/domain/challenge/controller/ChallengeController.java
+++ b/server/src/main/java/mainproject/domain/challenge/controller/ChallengeController.java
@@ -45,7 +45,7 @@ public class ChallengeController {
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
-    final String postChallengeDescription = "hostMemberId: 회원번호 (회원 등록 후 챌린지 생성 가능)" + "\r\n" +
+    final String postChallengeDescription = "hostMemberId: 회원번호 (로그인 후 챌린지 생성 가능)" + "\r\n" +
             "category: 카테고리 (우리동네, 운동, 생활, 기타 중 입력)" + "\r\n" +
             "title: 챌린지 제목 (50자까지 입력 가능) " + "\r\n" +
             "content: 챌린지 설명 (500자까지 입력 가능) " + "\r\n" +

--- a/server/src/main/java/mainproject/domain/challenge/service/ChallengeService.java
+++ b/server/src/main/java/mainproject/domain/challenge/service/ChallengeService.java
@@ -9,8 +9,11 @@ import mainproject.global.category.Category;
 import mainproject.global.exception.BusinessLogicException;
 import mainproject.global.exception.ExceptionCode;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
+import java.security.Principal;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -150,10 +153,10 @@ public class ChallengeService {
         return findChallenge;
     }
 
-    public boolean checkMember(Authentication authentication, long challengeId) {
+    public boolean checkMember(Member principal, long challengeId) {
         Optional<Challenge> optionalChallenge = challengeRepository.findById(challengeId);
 
         return optionalChallenge.isPresent()
-                && optionalChallenge.get().getMember().getEmail().equals(authentication.getName());
+                && optionalChallenge.get().getMember().getEmail().equals(principal.getEmail());
     }
 }

--- a/server/src/main/java/mainproject/domain/challenger/Controller/ChallengerController.java
+++ b/server/src/main/java/mainproject/domain/challenger/Controller/ChallengerController.java
@@ -1,5 +1,8 @@
 package mainproject.domain.challenger.Controller;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import mainproject.domain.challenger.Dto.ChallengerPostDto;
 import mainproject.domain.challenger.Dto.ChallengerResponseDto;
 import mainproject.domain.challenger.Entity.Challenger;
@@ -16,6 +19,7 @@ import java.util.List;
 @RestController
 @RequestMapping(value = "api/challengers")
 @Validated
+@Api(tags = "챌린지 참가, 참가 챌린지 조회")
 public class ChallengerController {
     private final ChallengerService challengerService;
 
@@ -27,8 +31,9 @@ public class ChallengerController {
     }
 
     // 챌린지 참가
+    @ApiOperation(value = "챌린지 참가")
     @PostMapping
-    public ResponseEntity postChallenger(@RequestBody ChallengerPostDto request) {
+    public ResponseEntity postChallenger(@ApiParam(name = "회원번호, 참가할 챌린지번호 입력", value = postChallengerDescription, required = true) @RequestBody ChallengerPostDto request) {
         Challenger challenger = challengerService.createChallenger(mapper.challengerPostDtoToChallenger(request));
 
         ChallengerResponseDto response = mapper.challengerToChallengerResponseDto(challenger);
@@ -36,7 +41,12 @@ public class ChallengerController {
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
+    final String postChallengerDescription = "memberId: 회원번호 (로그인 후 챌린지 신청 가능)" + "\r\n" +
+            "challengeId: 챌린지번호 (시작 전 상태의 챌린지만 신청 가능)";
+
     // 회원이 참가 중인 챌린지 조회
+    @ApiOperation(value = "회원이 참가 중인 챌린지 조회")
+    @ApiParam(name = "회원번호 입력", value = "회원번호 입력", required = true)
     @GetMapping("/{member-id}/challenging")
     public ResponseEntity getChallengingChallenges(@PathVariable("member-id") @Positive long memberId) {
         List<Challenger> challengers = challengerService.findChallengingChallenges(memberId);
@@ -47,6 +57,8 @@ public class ChallengerController {
     }
 
     // 회원이 참가했던 챌린지 조회
+    @ApiOperation(value = "회원이 참가했던 챌린지 조회")
+    @ApiParam(name = "회원번호 입력", value = "회원번호 입력", required = true)
     @GetMapping("/{member-id}/challenged")
     public ResponseEntity getChallengedChallenges(@PathVariable("member-id") @Positive long memberId) {
         List<Challenger> challengers = challengerService.findChallengedChallenges(memberId);

--- a/server/src/main/java/mainproject/domain/challenger/Dto/ChallengerPostDto.java
+++ b/server/src/main/java/mainproject/domain/challenger/Dto/ChallengerPostDto.java
@@ -1,5 +1,6 @@
 package mainproject.domain.challenger.Dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import mainproject.domain.challenge.entity.Challenge;
 import mainproject.domain.member.entity.Member;
@@ -11,8 +12,10 @@ import javax.validation.constraints.Positive;
 public class ChallengerPostDto {
     @NotNull
     @Positive
+    @ApiModelProperty(required = true, example = "1")
     private long memberId;
 
+    @ApiModelProperty(hidden = true)
     public Member getMember() {
         Member member = new Member();
         member.setId(memberId);
@@ -21,8 +24,10 @@ public class ChallengerPostDto {
 
     @NotNull
     @Positive
+    @ApiModelProperty(required = true, example = "1")
     private long challengeId;
 
+    @ApiModelProperty(hidden = true)
     public Challenge getChallenge() {
         Challenge challenge = new Challenge();
         challenge.setChallengeId(challengeId);

--- a/server/src/main/java/mainproject/domain/challenger/Service/ChallengerService.java
+++ b/server/src/main/java/mainproject/domain/challenger/Service/ChallengerService.java
@@ -9,6 +9,7 @@ import mainproject.domain.member.entity.Member;
 import mainproject.domain.member.service.MemberService;
 import mainproject.global.exception.BusinessLogicException;
 import mainproject.global.exception.ExceptionCode;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -84,5 +85,12 @@ public class ChallengerService {
         return findChallenger;
     }
 
-    // TODO: 참가자수++
+    public boolean checkMember(Member principal, long memberId) {
+        List<Challenger> optionalChallenger = challengerRepository.findByMember_Id(memberId);
+
+        return !optionalChallenger.isEmpty()
+                && optionalChallenger.stream()
+                .filter(c -> !c.getMember().getEmail().equals(principal.getEmail()))
+                .count() > 0;
+    }
 }

--- a/server/src/main/java/mainproject/domain/security/config/SecurityConfiguration.java
+++ b/server/src/main/java/mainproject/domain/security/config/SecurityConfiguration.java
@@ -14,6 +14,8 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+import javax.swing.text.html.HTML;
+
 
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -48,10 +50,19 @@ public class SecurityConfiguration  {
                 .authorizeRequests(auth -> auth
                         .antMatchers("/h2/**").permitAll() // h2 데이터베이스 확인 가능하게
                         .antMatchers(HttpMethod.OPTIONS, "/**").permitAll() // preflight 요청 모두 pass
-                        .antMatchers(HttpMethod.POST, "/api/challenges/{challenges-Id}").hasRole("USER") // 챌린지 작성
-                        .antMatchers(HttpMethod.PATCH,"/api/challenges/{challenges-Id}").hasRole("USER") // 챌린지 수정
-                        .antMatchers(HttpMethod.DELETE, "/api/challenges/{challenges-Id}")
-                        .access("@ChallengerService.checkMember(authentication,#challenges-Id)")// 챌린지 삭제
+                        .antMatchers(HttpMethod.POST, "/api/challenges").hasRole("USER") // 챌린지 생성 TODO?
+
+                        .antMatchers(HttpMethod.DELETE, "/api/challenges/{challengeId}")
+                        .access("@challengeService.checkMember(principal, T(Long).parseLong(#challengeId))") // 챌린지 삭제
+
+                        .antMatchers(HttpMethod.POST, "api/challengers").hasRole("USER")    // 챌린지 참가 TODO?
+
+                        .antMatchers(HttpMethod.GET, "api/challengers/{memberId}/**")
+                        .access("@challengerService.checkMember(principal, T(Long).parseLong(#memberId))") // 회원이 참가중or참가했던 챌린지 조회
+
+                        .antMatchers(HttpMethod.POST, "api/snapshots")
+                        .access("@challengerService.checkMember(principal, snapshot.getMember().getId())")   // 인증사진 등록
+
                         .antMatchers(HttpMethod.POST, "/api/boards").hasRole("USER") // 게시판 글 작성
                         .antMatchers(HttpMethod.PATCH, "/api/boards/{boardId}")
                         .access("@BoardService.checkMember(authentication,#BoardId)") // 게시판 글 수정

--- a/server/src/main/java/mainproject/domain/snapshot/Controller/SnapshotController.java
+++ b/server/src/main/java/mainproject/domain/snapshot/Controller/SnapshotController.java
@@ -1,5 +1,8 @@
 package mainproject.domain.snapshot.Controller;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import mainproject.domain.snapshot.Dto.SnapshotPostDto;
 import mainproject.domain.snapshot.Dto.SnapshotResponseDto;
 import mainproject.domain.snapshot.Entity.Snapshot;
@@ -14,6 +17,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/snapshots")
+@Api(tags = "인증사진 등록, 조회")
 public class SnapshotController {
     private final SnapshotService snapshotService;
     private final SnapshotMapper mapper;
@@ -24,8 +28,10 @@ public class SnapshotController {
     }
 
     // 참가 중인 챌린지에 인증사진 등록
+    @ApiOperation(value = "참가 중인 챌린지에 인증사진 등록")
     @PostMapping
-    public ResponseEntity postSnapshot(@RequestBody SnapshotPostDto request) {
+    public ResponseEntity postSnapshot(@ApiParam(name = "상세정보 입력", value = postSnapshotDescription, required = true)
+                                           @RequestBody SnapshotPostDto request) {
         Snapshot snapshot = snapshotService.createSnapshot(mapper.snapshotPostDtoToSnapshot(request));
 
         SnapshotResponseDto response = mapper.snapshotToSnapshotResponseDto(snapshot);
@@ -33,7 +39,12 @@ public class SnapshotController {
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
+    final String postSnapshotDescription = "memberId: 회원번호 (로그인 후 인증사진 등록 가능)" + "\r\n" +
+            "challengeId: 챌린지번호 (회원이 참가 중인 챌린지에만 인증사진 등록 가능)";
+
     // 챌린지의 모든 참가자들의 인증사진 최신순 조회
+    @ApiOperation(value = "챌린지의 모든 참가자들의 인증사진 최신순 조회")
+    @ApiParam(name = "챌린지번호 입력", value = "챌린지번호 입력", required = true)
     @GetMapping("/{challenge-id}")
     public ResponseEntity getSnapshots(@PathVariable("challenge-id") @Positive long challengeId) {
         List<Snapshot> snapshots = snapshotService.findSnapshots(challengeId);

--- a/server/src/main/java/mainproject/domain/snapshot/Dto/SnapshotPostDto.java
+++ b/server/src/main/java/mainproject/domain/snapshot/Dto/SnapshotPostDto.java
@@ -1,5 +1,6 @@
 package mainproject.domain.snapshot.Dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import mainproject.domain.challenge.entity.Challenge;
 import mainproject.domain.member.entity.Member;
@@ -11,8 +12,10 @@ import javax.validation.constraints.Positive;
 public class SnapshotPostDto {
     @NotNull
     @Positive
+    @ApiModelProperty(required = true, example = "1")
     private long memberId;
 
+    @ApiModelProperty(hidden = true)
     public Member getMember() {
         Member member = new Member();
         member.setId(memberId);
@@ -21,8 +24,10 @@ public class SnapshotPostDto {
 
     @NotNull
     @Positive
+    @ApiModelProperty(required = true, example = "1")
     private long challengeId;
 
+    @ApiModelProperty(hidden = true)
     public Challenge getChallenge() {
         Challenge challenge = new Challenge();
         challenge.setChallengeId(challengeId);


### PR DESCRIPTION
## 작업내용
- Swagger를 사용한 API 문서화
  - 챌린지 참가, 참가 챌린지 조회 기능 설명 작성
  - 인증사진 등록, 조회 기능 설명 작성
- Swagger에서 메서드에서 JWT Token을 검증하는 기능 구현

Related: #34

## PR Checklist
- [x] PR Title을 다음 예시와 같이 작성했습니다. (e.g. #12 - feat: 회원가입 기능 구현)
- [x] 우측의 Reviewers, Assignees, Labels, Projects, Milestone을 적절하게 선택했습니다.
