### PR TITLE
#34 - feat: API 문서화

### DIFF
--- a/server/src/main/java/mainproject/domain/board/dto/BoardPatchDto.java
+++ b/server/src/main/java/mainproject/domain/board/dto/BoardPatchDto.java
@@ -1,9 +1,11 @@
 package mainproject.domain.board.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 
+import mainproject.domain.image.entity.Image;
 import mainproject.global.category.Category;
 
 import javax.validation.constraints.NotBlank;
@@ -24,6 +26,15 @@ public class BoardPatchDto {
     @NotBlank(message = "질문내용 수정을 하지 않을 경우 등록이 불가합니다.")
     private String content;
 
-    // private String boardImage;
+    @Positive
+    @ApiModelProperty(required = false, example = "1")
+    private long boardImageId;
+
+    @ApiModelProperty(hidden = true)
+    public Image getImage() {
+        Image image = new Image();
+        image.setImageId(boardImageId);
+        return image;
+    }
 
 }

--- a/server/src/main/java/mainproject/domain/board/dto/BoardPostDto.java
+++ b/server/src/main/java/mainproject/domain/board/dto/BoardPostDto.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import mainproject.domain.image.entity.Image;
 import mainproject.domain.member.entity.Member;
 import mainproject.global.category.Category;
 
@@ -34,5 +35,14 @@ public class BoardPostDto {
     @NotBlank(message = "질문내용 작성을 하지 않을 경우 등록이 불가합니다.")
     private String content;
 
-    // private String boardImage;   // TODO: 이미지파일
+    @Positive
+    @ApiModelProperty(required = false, example = "1")
+    private long boardImageId = 1L; // TODO: 기본값을 기본 게시글 이미지로 변경(로고?)
+
+    @ApiModelProperty(hidden = true)
+    public Image getImage() {
+        Image image = new Image();
+        image.setImageId(boardImageId);
+        return image;
+    }
 }

--- a/server/src/main/java/mainproject/domain/board/dto/BoardResponseDto.java
+++ b/server/src/main/java/mainproject/domain/board/dto/BoardResponseDto.java
@@ -18,7 +18,7 @@ public class BoardResponseDto {
 
     private String memberName;
 
-    // private Image profileImage;   // TODO: 이미지파일
+    private long profileImageId;
 
     private Category category;
 
@@ -26,7 +26,7 @@ public class BoardResponseDto {
 
     private String content;
 
-    //private Image boardImage;  // TODO: 이미지파일
+    private long boardImageId;
 
     private LocalDateTime createdAt;
 

--- a/server/src/main/java/mainproject/domain/board/entity/Board.java
+++ b/server/src/main/java/mainproject/domain/board/entity/Board.java
@@ -4,8 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import mainproject.domain.comment.entity.Comment;
-
-import mainproject.domain.comment.entity.Comment;
+import mainproject.domain.image.entity.Image;
 import mainproject.domain.member.entity.Member;
 import mainproject.global.category.Category;
 
@@ -25,11 +24,7 @@ public class Board implements Serializable {
     private long boardId;
 
     @ManyToOne
-    @JoinColumns({
-            @JoinColumn(name = "MEMBER_ID",referencedColumnName = "ID"),
-            @JoinColumn(name = "HOST_MEMBER_NAME", referencedColumnName = "NAME")
-            // @JoinColumn(name = "PROFILE_IMAGE", referencedColumnName = "PROFILE_IMAGE")  // TODO: 이미지파일
-    })
+    @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
     public void setMember(Member member) {
@@ -47,8 +42,16 @@ public class Board implements Serializable {
 
     private String content;
 
-    //private Image boardImage;  // TODO: 이미지파일
+    @OneToOne
+    @JoinColumn(name = "BOARD_IMAGE_ID")
+    private Image image;
 
+    public void setImage(Image image) {
+        this.image = image;
+        if (this.image.getBoard() != this) {
+            this.image.setBoard(this);
+        }
+    }
 
     @Column(updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now().withNano(0);

--- a/server/src/main/java/mainproject/domain/board/mapper/BoardMapper.java
+++ b/server/src/main/java/mainproject/domain/board/mapper/BoardMapper.java
@@ -20,8 +20,9 @@ public interface BoardMapper {
 
     @Mappings({
             @Mapping(source = "member.id", target = "memberId"),
-            @Mapping(source = "member.name", target = "memberName")
-            // @Mapping(source = "member.profileImage", target = "profileImage")    // TODO: 이미지파일
+            @Mapping(source = "member.name", target = "memberName"),
+            @Mapping(source = "member.image.imageId", target = "profileImageId"),
+            @Mapping(source = "image.imageId", target = "boardImageId")
     })
     BoardResponseDto boardToBoardResponseDto(Board board);
 

--- a/server/src/main/java/mainproject/domain/board/service/BoardService.java
+++ b/server/src/main/java/mainproject/domain/board/service/BoardService.java
@@ -49,6 +49,8 @@ public class BoardService {
                 .ifPresent(content -> findboard.setContent(content));
         Optional.ofNullable(board.getCategory())
                 .ifPresent(category -> findboard.setCategory(category));
+        Optional.ofNullable(board.getImage())
+                .ifPresent(image -> findboard.setImage(image));
         return boardRepository.save(findboard);
 
 

--- a/server/src/main/java/mainproject/domain/challenge/controller/ChallengeController.java
+++ b/server/src/main/java/mainproject/domain/challenge/controller/ChallengeController.java
@@ -55,6 +55,18 @@ public class ChallengeController {
             "snapshotStartAt: 인증 시작 시간 예) 00:00:00 (생략 가능, default = 00:00:00)" + "\r\n" +
             "snapshotEndAt: 인증 종료 시간 (시작 시간 이후로 설정 가능, 생략 가능, default = 23:59:59)";
 
+    // 챌린지 상세조회
+    @ApiOperation(value = "챌린지 상세조회")
+    @ApiParam(name = "챌린지번호 입력", value = "챌린지번호 입력", required = true)
+    @GetMapping("/{challenge-id}")
+    public ResponseEntity getChallenge(@PathVariable("challenge-id") @Positive long challengeId) {
+        Challenge challenge = challengeService.findChallenge(challengeId);
+
+        ChallengeResponseDto response = mapper.challengeToChallengeResponseDto(challenge);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
     // 챌린지 목록 최신순 조회
     @ApiOperation(value = "챌린지 목록 최신순 조회")
     @GetMapping("/new")
@@ -65,7 +77,6 @@ public class ChallengeController {
         List<ChallengeResponseDto> response = mapper.challengesToChallengeResponseDtos(challenges);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
-
     }
 
     // 챌린지 목록 참여자순 조회

--- a/server/src/main/java/mainproject/domain/challenge/controller/ChallengeController.java
+++ b/server/src/main/java/mainproject/domain/challenge/controller/ChallengeController.java
@@ -46,14 +46,15 @@ public class ChallengeController {
     }
 
     final String postChallengeDescription = "hostMemberId: 회원번호 (로그인 후 챌린지 생성 가능)" + "\r\n" +
-            "category: 카테고리 (우리동네, 운동, 생활, 기타 중 입력)" + "\r\n" +
+            "category: 카테고리 ([우리동네, 운동, 생활, 기타] 중 입력)" + "\r\n" +
             "title: 챌린지 제목 (50자까지 입력 가능) " + "\r\n" +
             "content: 챌린지 설명 (500자까지 입력 가능) " + "\r\n" +
+            "challengeImageId: 챌린지 이미지번호 (이미지 업로드 후 사용 가능, 생략 가능)" + "\r\n" +
             "startAt: 챌린지 시작 날짜 예) 2023-02-01 (내일 이후부터 선택 가능)" + "\r\n" +
-            "endAt: 챌린지 종료 날짜 (시작 날짜 이후로 설정 가능)" + "\r\n" +
+            "endAt: 챌린지 종료 날짜 예) 2023-03-31 (시작 날짜 이후로 설정 가능)" + "\r\n" +
             "frequency: 인증 빈도 (생략 가능, default = 매일)" + "\r\n" +
-            "snapshotStartAt: 인증 시작 시간 예) 00:00:00 (생략 가능, default = 00:00:00)" + "\r\n" +
-            "snapshotEndAt: 인증 종료 시간 (시작 시간 이후로 설정 가능, 생략 가능, default = 23:59:59)";
+            "snapshotStartAt: 인증 시작 시간 예) 00:00 / 00:00:00 (생략 가능, default = 00:00:00)" + "\r\n" +
+            "snapshotEndAt: 인증 종료 시간 예) 22:00 / 23:59:59 (시작 시간 이후로 설정 가능, 생략 가능, default = 23:59:59)";
 
     // 챌린지 상세조회
     @ApiOperation(value = "챌린지 상세조회")

--- a/server/src/main/java/mainproject/domain/challenge/dto/ChallengePostDto.java
+++ b/server/src/main/java/mainproject/domain/challenge/dto/ChallengePostDto.java
@@ -41,8 +41,9 @@ public class ChallengePostDto {
     @ApiModelProperty(required = true, example = "우리동네에서 운동 후 하루에 한 번 인증사진을 등록하시면 됩니다.")
     private String content;
 
+    @Positive
     @ApiModelProperty(required = false, example = "1")
-    private long challengeImageId = 1L;
+    private long challengeImageId = 1L; // TODO: 기본값을 기본 챌린지 이미지로 변경
 
     @ApiModelProperty(hidden = true)
     public Image getImage() {

--- a/server/src/main/java/mainproject/domain/challenge/dto/ChallengePostDto.java
+++ b/server/src/main/java/mainproject/domain/challenge/dto/ChallengePostDto.java
@@ -32,12 +32,10 @@ public class ChallengePostDto {
     private Category category;
 
     @NotBlank(message = "제목을 입력하세요.")
-    @Size(max = 50, message = "제목은 50자까지 입력 가능합니다.")
     @ApiModelProperty(required = true, example = "같이 운동해요~")
     private String title;
 
     @NotBlank(message = "설명을 입력하세요.")
-    @Size(max = 500, message = "설명은 500자까지 입력 가능합니다.")
     @ApiModelProperty(required = true, example = "우리동네에서 운동 후 하루에 한 번 인증사진을 등록하시면 됩니다.")
     private String content;
 
@@ -66,7 +64,7 @@ public class ChallengePostDto {
     @AssertTrue(message = "종료 날짜는 시작 날짜 이후부터 선택 가능합니다.")
     @ApiModelProperty(hidden = true)
     public boolean isValidChallengePeriod() {
-        return endAt.isAfter(startAt);
+        return endAt.compareTo(startAt) >= 0;
     }
 
     @NotNull(message = "인증 빈도를 선택하세요.")
@@ -84,6 +82,6 @@ public class ChallengePostDto {
     @AssertTrue(message = "종료 시간은 시작 시간 이후부터 선택 가능합니다.")
     @ApiModelProperty(hidden = true)
     public boolean isValidSnapshotTime() {
-        return snapshotEndAt.isAfter(snapshotStartAt);
+        return snapshotEndAt.compareTo(snapshotStartAt) >= 0;
     }
 }

--- a/server/src/main/java/mainproject/domain/challenge/dto/ChallengePostDto.java
+++ b/server/src/main/java/mainproject/domain/challenge/dto/ChallengePostDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import mainproject.domain.challenge.entity.Frequency;
+import mainproject.domain.image.entity.Image;
 import mainproject.domain.member.entity.Member;
 import mainproject.global.category.Category;
 
@@ -40,7 +41,15 @@ public class ChallengePostDto {
     @ApiModelProperty(required = true, example = "우리동네에서 운동 후 하루에 한 번 인증사진을 등록하시면 됩니다.")
     private String content;
 
-    // private Image challengeImage;  // TODO: 이미지파일
+    @ApiModelProperty(required = false, example = "1")
+    private long challengeImageId = 1L;
+
+    @ApiModelProperty(hidden = true)
+    public Image getImage() {
+        Image image = new Image();
+        image.setImageId(challengeImageId);
+        return image;
+    }
 
     @NotNull(message = "시작 날짜를 선택하세요.")
     //@Future(message = "시작 날짜는 내일 이후부터 선택 가능합니다.") // 챌린지 상태변화 테스트시 주석 처리

--- a/server/src/main/java/mainproject/domain/challenge/dto/ChallengeResponseDto.java
+++ b/server/src/main/java/mainproject/domain/challenge/dto/ChallengeResponseDto.java
@@ -18,7 +18,7 @@ public class ChallengeResponseDto {
     private Category category;
     private String title;
     private String content;
-    // private Image challengeImage;  // TODO: 이미지파일
+    private long challengeImageId;
     private LocalDate startAt;
     private LocalDate endAt;
     private Frequency frequency;

--- a/server/src/main/java/mainproject/domain/challenge/dto/ChallengeResponseDto.java
+++ b/server/src/main/java/mainproject/domain/challenge/dto/ChallengeResponseDto.java
@@ -14,7 +14,7 @@ public class ChallengeResponseDto {
     private long challengeId;
     private long hostMemberId;
     private String hostMemberName;
-    // private Image hostProfileImage;   // TODO: 이미지파일
+    private long hostProfileImageId;
     private Category category;
     private String title;
     private String content;

--- a/server/src/main/java/mainproject/domain/challenge/entity/Challenge.java
+++ b/server/src/main/java/mainproject/domain/challenge/entity/Challenge.java
@@ -27,11 +27,7 @@ public class Challenge implements Serializable {
     private long challengeId;
 
     @ManyToOne
-    @JoinColumns({
-            @JoinColumn(name = "HOST_MEMBER_ID", referencedColumnName = "ID"),
-            @JoinColumn(name = "HOST_MEMBER_NAME", referencedColumnName = "NAME")
-            // @JoinColumn(name = "HOST_PROFILE_IMAGE", referencedColumnName = "PROFILE_IMAGE")  // TODO: 이미지파일
-    })
+    @JoinColumn(name = "HOST_MEMBER_ID")
     private Member member;
 
     public void setMember(Member member) {

--- a/server/src/main/java/mainproject/domain/challenge/entity/Challenge.java
+++ b/server/src/main/java/mainproject/domain/challenge/entity/Challenge.java
@@ -2,6 +2,7 @@ package mainproject.domain.challenge.entity;
 
 import lombok.Data;
 import mainproject.domain.challenger.Entity.Challenger;
+import mainproject.domain.image.entity.Image;
 import mainproject.domain.member.entity.Member;
 import mainproject.domain.snapshot.Entity.Snapshot;
 import mainproject.global.category.Category;
@@ -50,7 +51,16 @@ public class Challenge implements Serializable {
     @Column(nullable = false)
     private String content;
 
-    // private Image challengeImage;  // TODO: 이미지파일
+    @OneToOne
+    @JoinColumn(name = "CHALLENGE_IMAGE_ID")
+    private Image image;
+
+    public void setImage(Image image) {
+        this.image = image;
+        if (this.image.getChallenge() != this) {
+            this.image.setChallenge(this);
+        }
+    }
 
     @Column(nullable = false)
     private LocalDate startAt;

--- a/server/src/main/java/mainproject/domain/challenge/mapper/ChallengeMapper.java
+++ b/server/src/main/java/mainproject/domain/challenge/mapper/ChallengeMapper.java
@@ -16,7 +16,7 @@ public interface ChallengeMapper {
     @Mappings({
             @Mapping(source = "member.id", target = "hostMemberId"),
             @Mapping(source = "member.name", target = "hostMemberName"),
-            // @Mapping(source = "member.profileImage", target = "hostProfileImage")    // TODO: 이미지파일
+            @Mapping(source = "member.image.imageId", target = "hostProfileImageId"),
             @Mapping(source = "image.imageId", target = "challengeImageId")
     })
     ChallengeResponseDto challengeToChallengeResponseDto(Challenge challenge);

--- a/server/src/main/java/mainproject/domain/challenge/mapper/ChallengeMapper.java
+++ b/server/src/main/java/mainproject/domain/challenge/mapper/ChallengeMapper.java
@@ -17,6 +17,7 @@ public interface ChallengeMapper {
             @Mapping(source = "member.id", target = "hostMemberId"),
             @Mapping(source = "member.name", target = "hostMemberName"),
             // @Mapping(source = "member.profileImage", target = "hostProfileImage")    // TODO: 이미지파일
+            @Mapping(source = "image.imageId", target = "challengeImageId")
     })
     ChallengeResponseDto challengeToChallengeResponseDto(Challenge challenge);
 

--- a/server/src/main/java/mainproject/domain/challenge/service/ChallengeService.java
+++ b/server/src/main/java/mainproject/domain/challenge/service/ChallengeService.java
@@ -8,12 +8,8 @@ import mainproject.domain.member.service.MemberService;
 import mainproject.global.category.Category;
 import mainproject.global.exception.BusinessLogicException;
 import mainproject.global.exception.ExceptionCode;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
-import java.security.Principal;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;

--- a/server/src/main/java/mainproject/domain/challenge/service/ChallengeService.java
+++ b/server/src/main/java/mainproject/domain/challenge/service/ChallengeService.java
@@ -38,6 +38,13 @@ public class ChallengeService {
         return challengeRepository.save(challenge);
     }
 
+    // 챌린지 조회
+    public Challenge findChallenge(long challengeId) {
+        updateChallengeStatus();    // 현재 날짜에 맞춰 챌린지 상태 변경
+
+        return findVerifiedChallenge(challengeId);
+    }
+
     // 챌린지 목록 최신 생성일 순 조회
     public List<Challenge> findNewChallenges(Category category) {
         updateChallengeStatus();    // 현재 날짜에 맞춰 챌린지 상태 변경

--- a/server/src/main/java/mainproject/domain/challenger/Dto/ChallengerResponseDto.java
+++ b/server/src/main/java/mainproject/domain/challenger/Dto/ChallengerResponseDto.java
@@ -9,10 +9,9 @@ public class ChallengerResponseDto {
     private String challengerId;
     private long memberId;
     private String memberName;
-    // private Image profileImage;  // TODO: 이미지파일
+    private long profileImageId;
     private long challengeId;
     private String challengeName;
-    // private Image challengeImage;    // TODO: 이미지파일
-    // TODO: 참가자 수
+    private long challengeImageId;
     private LocalDateTime createdAt;
 }

--- a/server/src/main/java/mainproject/domain/challenger/Entity/Challenger.java
+++ b/server/src/main/java/mainproject/domain/challenger/Entity/Challenger.java
@@ -18,11 +18,7 @@ public class Challenger implements Serializable {
     private String challengerId;
 
     @ManyToOne
-    @JoinColumns({
-            @JoinColumn(name = "MEMBER_ID", referencedColumnName = "ID"),
-            @JoinColumn(name = "MEMBER_NAME", referencedColumnName = "NAME")
-            // @JoinColumn(name = "PROFILE_IMAGE", referencedColumnName = "PROFILE_IMAGE"),  // TODO: 이미지파일
-    })
+    @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
     public void setMember(Member member) {
@@ -33,11 +29,7 @@ public class Challenger implements Serializable {
     }
 
     @ManyToOne
-    @JoinColumns({
-            @JoinColumn(name = "CHALLENGE_ID", referencedColumnName = "CHALLENGE_ID"),
-            @JoinColumn(name = "CHALLENGE_NAME", referencedColumnName = "TITLE")
-            // @JoinColumn(name = "CHALLENGE_IMAGE", referencedColumnName = "CHALLENGE_IMAGE")  // TODO: 이미지파일
-    })
+    @JoinColumn(name = "CHALLENGE_ID")
     private Challenge challenge;
 
     public void setChallenge(Challenge challenge) {

--- a/server/src/main/java/mainproject/domain/challenger/Mapper/ChallengerMapper.java
+++ b/server/src/main/java/mainproject/domain/challenger/Mapper/ChallengerMapper.java
@@ -16,10 +16,10 @@ public interface ChallengerMapper {
     @Mappings({
             @Mapping(source = "member.id", target = "memberId"),
             @Mapping(source = "member.name", target = "memberName"),
-            // @Mapping(source = "member.profileImage", target = "profileImage"),   // TODO: 이미지파일
+            @Mapping(source = "member.image.imageId", target = "profileImageId"),
             @Mapping(source = "challenge.challengeId", target = "challengeId"),
-            @Mapping(source = "challenge.title", target = "challengeName")
-            // @Mapping(source = "challenge.challengeImage", target = "challengeImage")    // TODO: 이미지파일
+            @Mapping(source = "challenge.title", target = "challengeName"),
+            @Mapping(source = "challenge.image.imageId", target = "challengeImageId")
     })
     ChallengerResponseDto challengerToChallengerResponseDto(Challenger challenger);
 

--- a/server/src/main/java/mainproject/domain/challenger/Service/ChallengerService.java
+++ b/server/src/main/java/mainproject/domain/challenger/Service/ChallengerService.java
@@ -9,7 +9,6 @@ import mainproject.domain.member.entity.Member;
 import mainproject.domain.member.service.MemberService;
 import mainproject.global.exception.BusinessLogicException;
 import mainproject.global.exception.ExceptionCode;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.util.List;

--- a/server/src/main/java/mainproject/domain/comment/dto/CommentResponseDto.java
+++ b/server/src/main/java/mainproject/domain/comment/dto/CommentResponseDto.java
@@ -17,7 +17,7 @@ public class CommentResponseDto {
 
     private String memberName;
 
-    // private Image profileImage;   // TODO: 이미지파일
+    private long profileImageId;
 
     private long boardId;
 

--- a/server/src/main/java/mainproject/domain/comment/entity/Comment.java
+++ b/server/src/main/java/mainproject/domain/comment/entity/Comment.java
@@ -21,11 +21,7 @@ public class Comment implements Serializable {
     private Long commentId;
 
     @ManyToOne
-    @JoinColumns({
-            @JoinColumn(name = "MEMBER_ID", referencedColumnName = "ID"),
-            @JoinColumn(name = "MEMBER_NAME", referencedColumnName = "NAME")
-            // @JoinColumn(name = "PROFILE_IMAGE", referencedColumnName = "PROFILE_IMAGE")  // TODO: 이미지파일
-    })
+    @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
     public void setMember(Member member) {

--- a/server/src/main/java/mainproject/domain/comment/mapper/CommentMapper.java
+++ b/server/src/main/java/mainproject/domain/comment/mapper/CommentMapper.java
@@ -19,7 +19,7 @@ public interface CommentMapper {
     @Mappings({
             @Mapping(source = "member.id", target = "memberId"),
             @Mapping(source = "member.name", target = "memberName"),
-            // @Mapping(source = "member.profileImage", target = "profileImage"),   // TODO: 이미지파일
+            @Mapping(source = "member.image.imageId", target = "profileImageId"),
             @Mapping(source = "board.boardId", target = "boardId")
     })
     CommentResponseDto commentToCommentResponseDto(Comment savedComment);

--- a/server/src/main/java/mainproject/domain/image/controller/ImageController.java
+++ b/server/src/main/java/mainproject/domain/image/controller/ImageController.java
@@ -1,5 +1,8 @@
 package mainproject.domain.image.controller;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import mainproject.domain.image.dto.ImageResponseDto;
 import mainproject.domain.image.entity.Image;
 import mainproject.domain.image.mapper.ImageMapper;
@@ -12,7 +15,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 
 @RestController
-@RequestMapping(value = "/upload")
+@RequestMapping(value = "/api/upload")
+@Api(tags = "이미지파일 업로드")
 public class ImageController {
     private final ImageService imageService;
     private final ImageMapper mapper;
@@ -22,8 +26,10 @@ public class ImageController {
         this.mapper = mapper;
     }
 
-    @PostMapping
-    public ResponseEntity postImage(@RequestParam MultipartFile file) throws IOException {
+    @ApiOperation(value = "이미지파일 업로드")
+    @PostMapping    //(consumes = "multipart/form‑data")
+    public ResponseEntity postImage(@ApiParam(value = "파일 업로드", required = true)
+                                        @RequestParam MultipartFile file) throws IOException {
         Image image = imageService.uploadImage(file);
 
         ImageResponseDto response = mapper.imageToImageResponseDto(image);

--- a/server/src/main/java/mainproject/domain/image/entity/Image.java
+++ b/server/src/main/java/mainproject/domain/image/entity/Image.java
@@ -1,6 +1,7 @@
 package mainproject.domain.image.entity;
 
 import lombok.Data;
+import mainproject.domain.challenge.entity.Challenge;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -27,4 +28,14 @@ public class Image {
     @CreatedDate
     @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    @OneToOne(mappedBy = "image")
+    private Challenge challenge;
+
+    public void setChallenge(Challenge challenge) {
+        this.challenge = challenge;
+        if (challenge.getImage() != this) {
+            challenge.setImage(this);
+        }
+    }
 }

--- a/server/src/main/java/mainproject/domain/image/entity/Image.java
+++ b/server/src/main/java/mainproject/domain/image/entity/Image.java
@@ -1,7 +1,10 @@
 package mainproject.domain.image.entity;
 
 import lombok.Data;
+import mainproject.domain.board.entity.Board;
 import mainproject.domain.challenge.entity.Challenge;
+import mainproject.domain.member.entity.Member;
+import mainproject.domain.snapshot.Entity.Snapshot;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -30,12 +33,42 @@ public class Image {
     private LocalDateTime createdAt;
 
     @OneToOne(mappedBy = "image")
+    private Member member;
+
+    public void setMember(Member member) {
+        this.member = member;
+        if (member.getImage() != this) {
+            member.setImage(this);
+        }
+    }
+
+    @OneToOne(mappedBy = "image")
     private Challenge challenge;
 
     public void setChallenge(Challenge challenge) {
         this.challenge = challenge;
         if (challenge.getImage() != this) {
             challenge.setImage(this);
+        }
+    }
+
+    @OneToOne(mappedBy = "image")
+    private Snapshot snapshot;
+
+    public void setSnapshot(Snapshot snapshot) {
+        this.snapshot = snapshot;
+        if (snapshot.getImage()!= this) {
+            snapshot.setImage(this);
+        }
+    }
+
+    @OneToOne(mappedBy = "image")
+    private Board board;
+
+    public void setBoard(Board board) {
+        this.board = board;
+        if (board.getImage()!= this) {
+            board.setImage(this);
         }
     }
 }

--- a/server/src/main/java/mainproject/domain/image/service/ImageService.java
+++ b/server/src/main/java/mainproject/domain/image/service/ImageService.java
@@ -21,12 +21,12 @@ public class ImageService {
     public Image uploadImage(MultipartFile file) throws IOException {
         verifiedImage(file);    // 이미지파일 검증
 
-        // 이미지파일 임시 생성 후 저장
+        // 이미지 객체 임시 생성 후 저장
         Image image = createImage("temp", "temp", 1L);
         imageRepository.save(image);
 
         String originalFileName = file.getOriginalFilename();
-        String storedFileName = getStoredFileName(originalFileName, image.getImageId());    // storedFileName 생성
+        String storedFileName = image.getImageId() + "_" + originalFileName;
         Long fileSize = file.getSize();
 
         // 실제 파일명, 크기로 수정하여 저장
@@ -37,7 +37,7 @@ public class ImageService {
         return imageRepository.save(image);
     }
 
-    // 이미지파일 임시 생성
+    // 이미지 객체 생성
     public Image createImage(String originalFileName, String storedFileName, Long fileSize) {
         Image image = new Image();
         image.setOriginalFileName(originalFileName);
@@ -56,13 +56,5 @@ public class ImageService {
                 !file.getOriginalFilename().matches("^[a-zA-Zㄱ-ㅎ가-힣0-9-_]+\\.(jpg|JPG|png|jpeg|JPEG|heif|heic)$")) {
             throw new BusinessLogicException(ExceptionCode.FILE_NAME_NOT_VALID);
         }
-    }
-
-    // storedFileName 생성
-    public String getStoredFileName(String originalFileName, Long imageId) {
-        int pos = originalFileName.lastIndexOf(".");
-        String extension = originalFileName.substring(pos + 1);
-
-        return imageId + "." + extension;   // "{imageId}.{확장자}"
     }
 }

--- a/server/src/main/java/mainproject/domain/member/dto/MemberPatchDto.java
+++ b/server/src/main/java/mainproject/domain/member/dto/MemberPatchDto.java
@@ -2,6 +2,9 @@ package mainproject.domain.member.dto;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
+import mainproject.domain.image.entity.Image;
+
+import javax.validation.constraints.Positive;
 
 @Data
 public class MemberPatchDto {
@@ -14,4 +17,15 @@ public class MemberPatchDto {
 
     @ApiModelProperty(value = "회원-패스워드")
     private String password;
+
+    @Positive
+    @ApiModelProperty(value = "회원-프로필 사진", required = false, example = "1")
+    private long profileImageId;
+
+    @ApiModelProperty(hidden = true)
+    public Image getImage() {
+        Image image = new Image();
+        image.setImageId(profileImageId);
+        return image;
+    }
 }

--- a/server/src/main/java/mainproject/domain/member/dto/MemberPostDto.java
+++ b/server/src/main/java/mainproject/domain/member/dto/MemberPostDto.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import mainproject.domain.image.entity.Image;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.Email;
@@ -31,4 +32,11 @@ public class MemberPostDto {
     @Length(min = 8, max = 16, message = "비밀번호는 8자 이상, 16자 이하로 입력해주세요")
     @ApiModelProperty(value = "회원-비밀번호")
     private String password;
+
+    @ApiModelProperty(hidden = true)
+    public Image getImage() {
+        Image image = new Image();
+        image.setImageId(1L);   // TODO: 기본값을 기본 프로필 이미지로 변경
+        return image;
+    }
 }

--- a/server/src/main/java/mainproject/domain/member/dto/MemberResponseDto.java
+++ b/server/src/main/java/mainproject/domain/member/dto/MemberResponseDto.java
@@ -14,11 +14,11 @@ public class MemberResponseDto {
 
     private String name;
 
-    //private Image profileImage;  // TODO: 이미지파일
-
     private String email;
 
     private String password;
+
+    private long profileImageId;
 
     private List<String> roles;
 }

--- a/server/src/main/java/mainproject/domain/member/entity/Member.java
+++ b/server/src/main/java/mainproject/domain/member/entity/Member.java
@@ -5,6 +5,7 @@ import mainproject.domain.challenger.Entity.Challenger;
 import mainproject.domain.comment.entity.Comment;
 import mainproject.domain.board.entity.Board;
 import mainproject.domain.challenge.entity.Challenge;
+import mainproject.domain.image.entity.Image;
 import mainproject.domain.snapshot.Entity.Snapshot;
 
 import javax.persistence.*;
@@ -27,13 +28,22 @@ public class Member implements Serializable {
     @Column(length = 50, nullable = false)
     private String name;
 
-    // private Image profileImage;  // TODO: 이미지파일
-
     @Column(length = 100, nullable = false, updatable = false, unique = true)
     private String email;
 
     @Column(length = 100, nullable = false)
     private String password;
+
+    @OneToOne
+    @JoinColumn(name = "PROFILE_IMAGE_ID")
+    private Image image;
+
+    public void setImage(Image image) {
+        this.image = image;
+        if (this.image.getMember() != this) {
+            this.image.setMember(this);
+        }
+    }
 
     @ElementCollection(fetch = FetchType.EAGER)
     private List<String> roles;

--- a/server/src/main/java/mainproject/domain/member/mapper/MemberMapper.java
+++ b/server/src/main/java/mainproject/domain/member/mapper/MemberMapper.java
@@ -17,6 +17,7 @@ public class MemberMapper {
         member.setName(memberPostDto.getName());
         member.setEmail(memberPostDto.getEmail());
         member.setPassword(memberPostDto.getPassword());
+        member.setImage(memberPostDto.getImage());
 
         return member;
 
@@ -29,7 +30,7 @@ public class MemberMapper {
         member.setId(memberPatchDto.getId());
         member.setName(memberPatchDto.getName());
         member.setPassword(memberPatchDto.getPassword());
-        //:Todo 이미지 업로드 기능 넣을것
+        member.setImage(memberPatchDto.getImage());
 
         return member;
     }
@@ -43,6 +44,7 @@ public class MemberMapper {
         responseDto.setName(member.getName());
         responseDto.setEmail(member.getEmail());
         responseDto.setPassword(member.getPassword());
+        responseDto.setProfileImageId(member.getImage().getImageId());
 
         return responseDto;
 

--- a/server/src/main/java/mainproject/domain/member/service/MemberService.java
+++ b/server/src/main/java/mainproject/domain/member/service/MemberService.java
@@ -57,6 +57,8 @@ public class MemberService {
                 .ifPresent(name -> findMember.setName(name));
         Optional.ofNullable(member.getPassword())
                 .ifPresent(password -> findMember.setPassword(passwordEncoder.encode(password)));
+        Optional.ofNullable(member.getImage())
+                .ifPresent(image -> findMember.setImage(image));
 
         Member saveMember = memberRepository.save(findMember);
 

--- a/server/src/main/java/mainproject/domain/security/config/SecurityConfiguration.java
+++ b/server/src/main/java/mainproject/domain/security/config/SecurityConfiguration.java
@@ -50,12 +50,12 @@ public class SecurityConfiguration  {
                 .authorizeRequests(auth -> auth
                         .antMatchers("/h2/**").permitAll() // h2 데이터베이스 확인 가능하게
                         .antMatchers(HttpMethod.OPTIONS, "/**").permitAll() // preflight 요청 모두 pass
-                        .antMatchers(HttpMethod.POST, "/api/challenges").hasRole("USER") // 챌린지 생성 TODO?
+                        .antMatchers(HttpMethod.POST, "/api/challenges").hasRole("USER") // 챌린지 생성
 
                         .antMatchers(HttpMethod.DELETE, "/api/challenges/{challengeId}")
                         .access("@challengeService.checkMember(principal, T(Long).parseLong(#challengeId))") // 챌린지 삭제
 
-                        .antMatchers(HttpMethod.POST, "api/challengers").hasRole("USER")    // 챌린지 참가 TODO?
+                        .antMatchers(HttpMethod.POST, "api/challengers").hasRole("USER")    // 챌린지 참가
 
                         .antMatchers(HttpMethod.GET, "api/challengers/{memberId}/**")
                         .access("@challengerService.checkMember(principal, T(Long).parseLong(#memberId))") // 회원이 참가중or참가했던 챌린지 조회

--- a/server/src/main/java/mainproject/domain/snapshot/Dto/SnapshotPostDto.java
+++ b/server/src/main/java/mainproject/domain/snapshot/Dto/SnapshotPostDto.java
@@ -3,6 +3,7 @@ package mainproject.domain.snapshot.Dto;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import mainproject.domain.challenge.entity.Challenge;
+import mainproject.domain.image.entity.Image;
 import mainproject.domain.member.entity.Member;
 
 import javax.validation.constraints.NotNull;
@@ -34,5 +35,15 @@ public class SnapshotPostDto {
         return challenge;
     }
 
-    // private Image snapshotImage;  // TODO: 이미지파일
+    @NotNull
+    @Positive
+    @ApiModelProperty(required = true, example = "1")
+    private long snapshotImageId;
+
+    @ApiModelProperty(hidden = true)
+    public Image getImage() {
+        Image image = new Image();
+        image.setImageId(snapshotImageId);
+        return image;
+    }
 }

--- a/server/src/main/java/mainproject/domain/snapshot/Dto/SnapshotResponseDto.java
+++ b/server/src/main/java/mainproject/domain/snapshot/Dto/SnapshotResponseDto.java
@@ -9,10 +9,10 @@ public class SnapshotResponseDto {
     private String snapshotId;
     private long memberId;
     private String memberName;
-    // private Image profileImage;   // TODO: 이미지파일
+    private long profileImageId;
     private long challengeId;
     private String challengeName;
-    // private Image challengeImage; // TODO: 이미지파일
-    // private Image snapshotImage;  // TODO: 이미지파일
+    private long challengeImageId;
+    private long snapshotImageId;
     private LocalDateTime createdAt;
 }

--- a/server/src/main/java/mainproject/domain/snapshot/Entity/Snapshot.java
+++ b/server/src/main/java/mainproject/domain/snapshot/Entity/Snapshot.java
@@ -2,6 +2,7 @@ package mainproject.domain.snapshot.Entity;
 
 import lombok.Data;
 import mainproject.domain.challenge.entity.Challenge;
+import mainproject.domain.image.entity.Image;
 import mainproject.domain.member.entity.Member;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -18,11 +19,7 @@ public class Snapshot implements Serializable {
     private String snapshotId;
 
     @ManyToOne
-    @JoinColumns({
-            @JoinColumn(name = "MEMBER_ID", referencedColumnName = "ID"),
-            @JoinColumn(name = "MEMBER_NAME", referencedColumnName = "NAME")
-            // @JoinColumn(name = "PROFILE_IMAGE", referencedColumnName = "PROFILE_IMAGE")  // TODO: 이미지파일
-    })
+    @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
     public void setMember(Member member) {
@@ -33,12 +30,7 @@ public class Snapshot implements Serializable {
     }
 
     @ManyToOne
-    @JoinColumns({
-            @JoinColumn(name = "CHALLENGE_ID", referencedColumnName = "CHALLENGE_ID"),
-            @JoinColumn(name = "CHALLENGE_NAME", referencedColumnName = "TITLE")
-            // @JoinColumn(name = "CHALLENGE_IMAGE", referencedColumnName = "CHALLENGE_IMAGE"),  // TODO: 이미지파일
-            // TODO: 참가자 수
-    })
+    @JoinColumn(name = "CHALLENGE_ID")
     private Challenge challenge;
 
     public void setChallenge(Challenge challenge) {
@@ -48,7 +40,16 @@ public class Snapshot implements Serializable {
         }
     }
 
-    // private Image snapshotImage;  // TODO: 이미지파일
+    @OneToOne
+    @JoinColumn(name = "SNAPSHOT_IMAGE_ID")
+    private Image image;
+
+    public void setImage(Image image) {
+        this.image = image;
+        if (this.image.getSnapshot() != this) {
+            this.image.setSnapshot(this);
+        }
+    }
 
     @CreatedDate
     @Column(updatable = false)

--- a/server/src/main/java/mainproject/domain/snapshot/Mapper/SnapshotMapper.java
+++ b/server/src/main/java/mainproject/domain/snapshot/Mapper/SnapshotMapper.java
@@ -16,10 +16,11 @@ public interface SnapshotMapper {
     @Mappings({
             @Mapping(source = "member.id", target = "memberId"),
             @Mapping(source = "member.name", target = "memberName"),
-            // @Mapping(source = "member.profileImage", target = "profileImage"), // TODO: 이미지파일
+            @Mapping(source = "member.image.imageId", target = "profileImageId"),
             @Mapping(source = "challenge.challengeId", target = "challengeId"),
-            @Mapping(source = "challenge.title", target = "challengeName")
-            // @Mapping(source = "challenge.challengeImage", target = "challengeImage")  // TODO: 이미지파일
+            @Mapping(source = "challenge.title", target = "challengeName"),
+            @Mapping(source = "challenge.image.imageId", target = "challengeImageId"),
+            @Mapping(source = "image.imageId", target = "snapshotImageId")
     })
     SnapshotResponseDto snapshotToSnapshotResponseDto(Snapshot snapshot);
 

--- a/server/src/main/java/mainproject/global/config/SwaggerConfiguration.java
+++ b/server/src/main/java/mainproject/global/config/SwaggerConfiguration.java
@@ -21,7 +21,7 @@ public class SwaggerConfiguration {
         return new Docket(DocumentationType.SWAGGER_2)
                 .useDefaultResponseMessages(false)  // 기본 상태 코드에 대한 디폴트 메세지 비활성화
                 .select() // ApiSelectorBuilder를 생성하여 apis()와 paths()를 사용할 수 있게 해준다.
-                .apis(RequestHandlerSelectors.any())  // api 스펙이 작성되어 있는 패키지(Controller가 존재하는 패키지)를 지정하여 API를 문서화한다.
+                .apis(RequestHandlerSelectors.basePackage("mainproject.domain"))    // api 스펙이 작성되어 있는 패키지(Controller가 존재하는 패키지)를 지정하여 API를 문서화한다.
                 .paths(PathSelectors.any())   // apis()로 선택되어진 API중 특정 path 조건에 맞는 API들을 다시 필터링하여 문서화한다.
                 .build().apiInfo(apiInfo()) // 제목, 설명 등 문서에 대한 정보들을 설정하기 위해 호출한다.
                 .securityContexts(List.of(securityContext()))


### PR DESCRIPTION
## 작업내용
- 단일 챌린지 상세조회 구현
- 이미지 업로드 후 객체들과 매핑
- Controller basePackage 지정 (basic-error-controller 제거)
- 리팩토링

Related: #34

## PR Checklist
- [x] PR Title을 다음 예시와 같이 작성했습니다. (e.g. #12 - feat: 회원가입 기능 구현)
- [x] 우측의 Reviewers, Assignees, Labels, Projects, Milestone을 적절하게 선택했습니다.
